### PR TITLE
fix: edit channel name regex to allow FEEL expressions

### DIFF
--- a/element-templates/slack-connector.json
+++ b/element-templates/slack-connector.json
@@ -118,7 +118,7 @@
       "constraints": {
         "notEmpty": true,
         "pattern": {
-          "value": "^[-_a-z0-9]{1,80}$",
+          "value": "^(=|[-_a-z0-9]{1,80}$)",
           "message": "May contain up to 80 lowercase letters, digits, underscores, and dashes"
         }
       },


### PR DESCRIPTION
## Description

Updated ``New Channel Name`` field regex, as the previous one didn't allow FEEL expressions

## Related issues

#146 

